### PR TITLE
Import ocaml-findlib-1.9.8-1.xs8.src.rpm

### DIFF
--- a/SOURCES/findlib-1.9.6.tar.gz
+++ b/SOURCES/findlib-1.9.6.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2df996279ae16b606db5ff5879f93dbfade0898db9f1a3e82f7f845faa2930a2
-size 271246

--- a/SOURCES/findlib-1.9.8.tar.gz
+++ b/SOURCES/findlib-1.9.8.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:662c910f774e9fee3a19c4e057f380581ab2fc4ee52da4761304ac9c31b8869d
+size 274668

--- a/SOURCES/ocaml-findlib-toolbox.patch
+++ b/SOURCES/ocaml-findlib-toolbox.patch
@@ -1,0 +1,117 @@
+--- findlib-1.9.6/src/findlib-toolbox/Makefile.orig	2022-09-24 09:13:16.000000000 -0600
++++ findlib-1.9.6/src/findlib-toolbox/Makefile	2023-06-16 08:46:01.965686356 -0600
+@@ -9,7 +9,7 @@ opt:
+ 	true
+ 
+ make_wizard$(EXEC_SUFFIX): make_wizard.ml
+-	ocamlc -o make_wizard$(EXEC_SUFFIX) -I +unix -I +labltk -I ../findlib \
++	ocamlc -o make_wizard$(EXEC_SUFFIX) -I +str -I +unix -I +labltk -I ../findlib \
+ 		unix.cma str.cma labltk.cma findlib.cma make_wizard.ml
+ 
+ install:
+--- findlib-1.9.6/src/findlib-toolbox/make_wizard.ml.orig	2022-09-24 09:13:16.000000000 -0600
++++ findlib-1.9.6/src/findlib-toolbox/make_wizard.ml	2023-06-16 08:50:49.066603769 -0600
+@@ -468,23 +468,23 @@ let makemake() =
+           mkquote(metaquote !wiz_package_description);
+       "byte_objects", 
+           String.concat " " (List.map 
+-			       (fun m -> String.uncapitalize m ^ ".cmo")
++			       (fun m -> String.uncapitalize_ascii m ^ ".cmo")
+ 			       !wiz_objects);
+       "nat_objects",
+           String.concat " " (List.map 
+-			       (fun m -> String.uncapitalize m ^ ".cmx")
++			       (fun m -> String.uncapitalize_ascii m ^ ".cmx")
+ 			       !wiz_objects);
+       "byte_executables",
+           String.concat " " byte_execs;
+       "byte_exec_objects",
+           String.concat " " (List.map 
+-			       (fun m -> String.uncapitalize m ^ ".cmo")
++			       (fun m -> String.uncapitalize_ascii m ^ ".cmo")
+ 			       byte_exec_modules);
+       "nat_executables",
+           String.concat " " nat_execs;
+       "nat_exec_objects",
+           String.concat " " (List.map 
+-			       (fun m -> String.uncapitalize m ^ ".cmx")
++			       (fun m -> String.uncapitalize_ascii m ^ ".cmx")
+ 			       nat_exec_modules);
+       "prereqs",
+           String.concat " " required_packages;
+@@ -526,7 +526,7 @@ let makemake() =
+        let deptargets =
+ 	 String.concat " " (List.map 
+ 			      (fun m -> 
+-				 let m' = String.uncapitalize m in
++				 let m' = String.uncapitalize_ascii m in
+ 				 m' ^ ".ml " ^ m' ^ ".mli")
+ 			      !modlist) in
+        write "makemake_exec" ( [ "switches", switches;
+@@ -543,7 +543,7 @@ let makemake() =
+        if is_byte_exec execname then begin
+ 	 let execobjs = 
+ 	   String.concat " " (List.map 
+-				(fun m -> String.uncapitalize m ^ ".cmo")
++				(fun m -> String.uncapitalize_ascii m ^ ".cmo")
+ 				!modlist) in
+ 	 write "byte_exec" ( ["execname", execname;
+ 			      "execobjs", execobjs ] @ variables )
+@@ -555,7 +555,7 @@ let makemake() =
+        if not (is_byte_exec execname) then begin
+ 	 let execobjs = 
+ 	   String.concat " " (List.map 
+-				(fun m -> String.uncapitalize m ^ ".cmx")
++				(fun m -> String.uncapitalize_ascii m ^ ".cmx")
+ 				!modlist) in
+ 	 write "nat_exec" ( ["execname", execname;
+ 			     "execobjs", execobjs ] @ variables )
+@@ -1090,7 +1090,7 @@ let pkginfo lb row =  (* when the user r
+ 	  let files = Array.to_list(Sys.readdir dir) in
+ 	  List.map
+ 	    (fun name -> 
+-	       String.capitalize (Filename.chop_suffix name ".cmi"))
++	       String.capitalize_ascii (Filename.chop_suffix name ".cmi"))
+ 	    (List.filter
+ 	       (fun name -> 
+ 		  Filename.check_suffix name ".cmi")
+@@ -1128,7 +1128,7 @@ let preprocessor_scan_extensions() =
+ 	 not (List.mem pkg plist)
+       )
+       !wiz_camlp4_selected in
+-  List.sort Pervasives.compare (plist @ plist')
++  List.sort Stdlib.compare (plist @ plist')
+ ;;
+ 
+ 
+@@ -1196,7 +1196,7 @@ add_screen preprocessor_screen;;
+ 
+ let prerequisites_scan_packages() =
+   (* Find out all packages *)
+-  List.sort Pervasives.compare (Fl_package_base.list_packages())
++  List.sort Stdlib.compare (Fl_package_base.list_packages())
+ ;;
+ 
+ 
+@@ -1255,10 +1255,10 @@ let buildlib_scan_modules() =
+   let files'' =
+     List.map
+       (fun f ->
+-	 String.capitalize (Filename.chop_extension f)
++	 String.capitalize_ascii (Filename.chop_extension f)
+       )
+       files' in
+-  remove_dups (List.sort Pervasives.compare files'')
++  remove_dups (List.sort Stdlib.compare files'')
+ ;;
+ 
+ 
+@@ -1353,7 +1353,7 @@ build any.";
+ 	 end
+ 	 else begin
+ 	   wiz_executables := 
+-	     List.sort Pervasives.compare (name :: !wiz_executables);
++	     List.sort Stdlib.compare (name :: !wiz_executables);
+ 	   wiz_exec_objects := (name, ref []) :: !wiz_exec_objects;
+ 	   wiz_exec_native := (name, ref false) :: !wiz_exec_native;
+ 	   !update_listbox();

--- a/SPECS/ocaml-findlib.spec
+++ b/SPECS/ocaml-findlib.spec
@@ -1,16 +1,17 @@
-%global package_speccommit f84c6bcb734a24ac2813d14f98c641bbca414ef8
-%global usver 1.9.6
-%global xsver 3
+%global package_speccommit 6a7dad34c7104f909a70bf475858100b8dda0a49
+%global usver 1.9.8
+%global xsver 1
 %global xsrel %{xsver}%{?xscount}%{?xshash}
 
 Name:           ocaml-findlib
-Version:        1.9.6
+Version:        1.9.8
 Release:        %{?xsrel}%{?dist}
 Summary:        Objective CAML package manager and build helper
 License:        MIT
 
 URL:            http://projects.camlcity.org/projects/findlib.html
-Source0: findlib-1.9.6.tar.gz
+Source0: findlib-1.9.8.tar.gz
+Patch0: ocaml-findlib-toolbox.patch
 
 BuildRequires:  ocaml >= 4.02.0
 BuildRequires:  ocaml-compiler-libs
@@ -20,8 +21,8 @@ BuildRequires:  gawk
 BuildRequires:  make
 Requires:       ocaml
 
-%global __ocaml_requires_opts -i Asttypes -i Parsetree
-
+# Do not require ocaml-compiler-libs at runtime
+%global __ocaml_requires_opts -i Asttypes -i Build_path_prefix_map -i Cmi_format -i Env -i Ident -i Identifiable -i Load_path -i Location -i Longident -i Misc -i Outcometree -i Parsetree -i Path -i Primitive -i Shape -i Subst -i Topdirs -i Toploop -i Type_immediacy -i Types -i Warnings
 
 %description
 Objective CAML package manager and build helper.
@@ -40,9 +41,28 @@ developing applications that use %{name}.
 %prep
 %autosetup -p1 -n findlib-%{version}
 
+# Fix character encoding
+iconv -f ISO8859-1 -t UTF-8 doc/README > doc/README.utf8
+touch -r doc/README doc/README.utf8
+mv doc/README.utf8 doc/README
+
+# Fix the OCaml core man directory
+sed -i 's,/usr/local/man,%{_mandir},' configure
+
+# Build an executable that is not damaged by stripping
+sed -i 's/\(custom=\)-custom/\1-output-complete-exe/' configure
+
+# Skip broken test for ocamlopt -g
+sed -i '/^ocamlopt -g/d' configure
+
 
 %build
-./configure -config %{_sysconfdir}/ocamlfind.conf \
+ocamlc -version
+ocamlc -where
+(cd tools/extract_args && make)
+tools/extract_args/extract_args -o src/findlib/ocaml_args.ml ocamlc ocamlcp ocamlmktop ocamlopt ocamldep ocamldoc ||:
+cat src/findlib/ocaml_args.ml
+./configure -config %{_sysconfdir}/findlib.conf \
   -bindir %{_bindir} \
   -sitelib `ocamlc -where` \
   -mandir %{_mandir} \
@@ -53,18 +73,21 @@ rm doc/guide-html/TIMESTAMP
 
 
 %install
-# Grrr destdir grrrr
 mkdir -p $RPM_BUILD_ROOT%{_bindir}
 mkdir -p $RPM_BUILD_ROOT%{_mandir}/man{1,5}
+mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}
 make install \
      prefix=$RPM_BUILD_ROOT \
      OCAMLFIND_BIN=%{_bindir} \
+     OCAMLFIND_CONF=%{_sysconfdir} \
      OCAMLFIND_MAN=%{_mandir}
+rmdir $RPM_BUILD_ROOT%{_mandir}/man3
+
 
 
 %files
 %doc LICENSE doc/README
-%config(noreplace) %{_sysconfdir}/ocamlfind.conf
+%config(noreplace) %{_sysconfdir}/findlib.conf
 %{_bindir}/*
 %{_mandir}/man1/*
 %{_mandir}/man5/*
@@ -75,8 +98,6 @@ make install \
 %exclude %{_libdir}/ocaml/findlib/*.cmxa
 %exclude %{_libdir}/ocaml/findlib/*.mli
 %exclude %{_libdir}/ocaml/findlib/Makefile.config
-%exclude %{_libdir}/ocaml/findlib/make_wizard
-%exclude %{_libdir}/ocaml/findlib/make_wizard.pattern
 # Had to disable this in OCaml 4.06, unclear why.
 #%%{_libdir}/ocaml/num-top
 
@@ -90,6 +111,9 @@ make install \
 
 
 %changelog
+* Fri Oct 10 2025 Rob Hoes <rob.hoes@citrix.com> - 1.9.8-1
+- Use 1.9.8
+
 * Fri May 31 2024 Pau Ruiz Safont <pau.ruizsafont@cloud.com> - 1.9.6-3
 - Bump release and rebuild
 


### PR DESCRIPTION
This was done to enable testing of the OCaml 5 compiler.

I did not modify the changelog because only the xenserver one is present

Test build at https://koji.xcp-ng.org/taskinfo?taskID=92618